### PR TITLE
Use full namespace to write serialized message in filesystem to avoid naming conflict

### DIFF
--- a/src/Filesystem/ZddMessageFilesystem.php
+++ b/src/Filesystem/ZddMessageFilesystem.php
@@ -67,8 +67,9 @@ final class ZddMessageFilesystem
     private function getDirectoryAndShortname(string $classFqcn): array
     {
         $path = explode('\\', $classFqcn);
-        $directory = $path[\count($path) - 2];
         $shortName = end($path);
+        array_pop($path);
+        $directory = implode('/', $path);
 
         return [$directory, $shortName];
     }

--- a/tests/Fixtures/App/Messages/Config/MessageConfig.php
+++ b/tests/Fixtures/App/Messages/Config/MessageConfig.php
@@ -9,6 +9,7 @@ use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithNullabl
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithPrivateConstructor;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Input\Locale;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Input\Status;
+use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Other;
 
 class MessageConfig implements ZddMessageConfigInterface
 {
@@ -21,6 +22,7 @@ class MessageConfig implements ZddMessageConfigInterface
             DummyMessageWithNullableNumberProperty::class,
             DummyMessageWithPrivateConstructor::class,
             DummyMessageWithAllManagedTypes::class,
+            Other\DummyMessage::class,
         ];
     }
 

--- a/tests/Fixtures/App/Messages/Other/DummyMessage.php
+++ b/tests/Fixtures/App/Messages/Other/DummyMessage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Other;
+
+final class DummyMessage
+{
+    public function __construct(
+        public readonly array $contents
+    ) {
+    }
+}

--- a/tests/Func/GenerateZddMessageCommandTest.php
+++ b/tests/Func/GenerateZddMessageCommandTest.php
@@ -21,7 +21,7 @@ class GenerateZddMessageCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $this->command = new CommandTester((new Application($kernel))->find('yousign:zdd-message:generate'));
         $customBasePathFile = $kernel->getContainer()->getParameter('custom_path_file');
-        $this->serializedMessagesDir = $customBasePathFile.'/Messages';
+        $this->serializedMessagesDir = $customBasePathFile.'/Yousign/ZddMessageBundle/Tests/Fixtures/App/Messages';
     }
 
     protected function tearDown(): void
@@ -49,6 +49,7 @@ class GenerateZddMessageCommandTest extends KernelTestCase
           2   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithNullableNumberProperty  
           3   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithPrivateConstructor      
           4   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithAllManagedTypes         
+          5   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Other\DummyMessage                      
          --- ---------------------------------------------------------------------------------------------  
         EOF;
 

--- a/tests/Func/ListZddMessageCommandTest.php
+++ b/tests/Func/ListZddMessageCommandTest.php
@@ -30,6 +30,7 @@ class ListZddMessageCommandTest extends KernelTestCase
           2   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithNullableNumberProperty  
           3   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithPrivateConstructor      
           4   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithAllManagedTypes         
+          5   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Other\DummyMessage                      
          --- ---------------------------------------------------------------------------------------------  
         EOF;
 

--- a/tests/Func/ValidateZddMessageCommandTest.php
+++ b/tests/Func/ValidateZddMessageCommandTest.php
@@ -22,7 +22,7 @@ class ValidateZddMessageCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $this->command = new CommandTester((new Application(self::$kernel))->find('yousign:zdd-message:validate'));
         $customBasePathFile = $kernel->getContainer()->getParameter('custom_path_file');
-        $this->serializedMessagesDir = $customBasePathFile.'/Messages';
+        $this->serializedMessagesDir = $customBasePathFile.'/Yousign/ZddMessageBundle/Tests/Fixtures/App/Messages';
 
         MessageConfig::$messagesToAssert = [
             DummyMessage::class,


### PR DESCRIPTION
Hi ! Currently, if you use the same naming for a message in different namespace, the first serialized message is override by the second, and the validation process will trigger a class mismatch.

Using the full namespace of the message will avoid this definitively.

Unfortunately, this change means that when we switch to this new version, we won't be able to catch errors because generation and validation will no longer be based on the same path.