### PR TITLE
feat: support for custom message generation in `ZddMessageConfigInterface`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ phpcs: ## Run PHP CS Fixer
 test: ## Run code tests
 	./vendor/bin/phpunit --testdox
 
-phpstan:
+phpstan: ## Run PHPStan static analysis
 	./vendor/bin/phpstan analyse src --level=9
 
 test-phpcs: ## Run coding standard tests

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Create a class to configure the messages to assert and how to create them:
 
 namespace App\Message;
 
+use Yousign\ZddMessageBundle\Config\CustomMessageGeneratorInterface;
 use Yousign\ZddMessageBundle\Config\ZddMessageConfigInterface;
 
-class MessageConfig implements ZddMessageConfigInterface
+class MessageConfig implements ZddMessageConfigInterface, CustomMessageGeneratorInterface
 {
     /**
      * Return the list of messages to assert.
@@ -54,10 +55,13 @@ class MessageConfig implements ZddMessageConfigInterface
     }
 
     /**
-     * If you need full control over how a specific message instance is created,
-     * use this method to return a fully instantiated message object.
+     * Optional: Implement CustomMessageGeneratorInterface if you need full control
+     * over how a specific message instance is created.
      * This is useful when the default instantiation (using reflection and property injection)
      * is not sufficient or when your message requires specific constructor logic.
+     *
+     * WARNING: The object must be instantiated with minimum requirements (i.e., nullable properties
+     * must be set as null) in order to ensure a good ZDD test.
      */
     #[\Override]
     public function generateCustomMessage(string $className): ?object

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ class MessageConfig implements ZddMessageConfigInterface
     /**
      * Return the list of messages to assert.
      */
+    #[\Override]
     public function getMessageToAssert(): array
     {
         return [
@@ -41,11 +42,27 @@ class MessageConfig implements ZddMessageConfigInterface
      * If your message contains no scalar value as parameter such like value enums, value object more complex object,
      * you should use this method to return value for each type hint.
      */
+    #[\Override]
     public function generateValueForCustomPropertyType(string $type): mixed
     {
         return match ($type) {
             'App\ValueObject\Email' => new App\ValueObject\Email('dummy@email.fr'),
             'App\Enum\MyEnum' => App\Enum\MyEnum::MY_VALUE,
+            default => null,
+        };
+    }
+
+    /**
+     * If you need full control over how a specific message instance is created,
+     * use this method to return a fully instantiated message object.
+     * This is useful when the default instantiation (using reflection and property injection)
+     * is not sufficient or when your message requires specific constructor logic.
+     */
+    #[\Override]
+    public function generateCustomMessage(string $className): ?object
+    {
+        return match ($className) {
+            App\Message\ComplexMessage::class => new App\Message\ComplexMessage('custom data'),
             default => null,
         };
     }

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@ A Symfony Bundle to use when you want to assert that messages used with Message 
 
 ## Getting started
 ### Installation
-You can easily install Zdd Message bundle by composer
+First, install the bundle with composer:
 ```
 $ composer require yousign/zdd-message-bundle
 ```
-Then, bundle should be registered. Just verify that `config\bundles.php` is containing :
+
+Then, verify that the bundle has been registered in `config/bundles.php`:
 ```php
 Yousign\ZddMessageBundle\ZddMessageBundle::class => ['all' => true],
 ```
 
 ### Configuration
-Once the bundle is installed, you should create a class to configure the messages to assert and how to create them:
+Create a class to configure the messages to assert and how to create them:
 
 ```php
 <?php
@@ -69,18 +70,18 @@ class MessageConfig implements ZddMessageConfigInterface
 }
 ```
 
-When the class is created, you can register it as a service.
+Then, register this class as a service.
 
 ```yaml
 # config/services.yaml
-  App\Message\MessageConfig: ~
+  App\Message\MessageConfig:
 ```
 
-Then, you should register it in the configuration (`config/packages/zdd_message.yaml`) :
+Finish by updating the configuration with this new service in `config/packages/zdd_message.yaml`:
 ```yaml
 # config/packages/zdd_message.yaml
   zdd_message:
-    serialized_messages_dir: 'var/serialized_messages' # The directory where the serialized messages will be stored (default: '%kernel.logs_dir%')
+    message_config_service: App\Message\MessageConfig
 ```
 
 #### Optional configuration
@@ -88,7 +89,7 @@ Then, you should register it in the configuration (`config/packages/zdd_message.
 **Use a custom serializer**
 
 Option to use different serializer.
-Possible options :
+Possible options:
 - `Yousign\ZddMessageBundle\Serializer\ZddMessageMessengerSerializer` (default, already configured for messenger serialization in messenger.yaml)
 - Define your own serializer
   - Create a service that implement `Yousign\ZddMessageBundle\Serializer\SerializerInterface`
@@ -97,6 +98,17 @@ Possible options :
 # config/packages/zdd_message.yaml
   zdd_message:
     serializer: '<your-service-id>'
+```
+
+**Custom directory for serialized messages**
+
+Option to specify a custom directory where serialized messages will be stored.
+
+```yaml
+# config/packages/zdd_message.yaml
+zdd_message:
+  # ...
+  serialized_messages_dir: '%kernel.project_dir%/custom/path' # Default: '%kernel.project_dir%/var/zdd-message'
 ```
 
 **Detect messages not tracked**

--- a/src/Config/CustomMessageGeneratorInterface.php
+++ b/src/Config/CustomMessageGeneratorInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yousign\ZddMessageBundle\Config;
+
+/**
+ * @experimental
+ */
+interface CustomMessageGeneratorInterface
+{
+    /**
+     * If you need full control over how a specific message instance is created,
+     * use this method to return a fully instantiated message object.
+     * This is useful when the default instantiation (using reflection and property injection)
+     * is not sufficient or when your message requires specific constructor logic.
+     *
+     * WARNING: The object must be instantiated with minimum requirements (i.e., nullable properties
+     * must be set as null) in order to ensure a good ZDD test.
+     *
+     * @template T of object
+     *
+     * @param class-string<T> $className
+     *
+     * @return ?T The fully instantiated message object, or null if the default instantiation should be used
+     */
+    public function generateCustomMessage(string $className): ?object;
+}

--- a/src/Config/ZddMessageConfigInterface.php
+++ b/src/Config/ZddMessageConfigInterface.php
@@ -51,4 +51,18 @@ interface ZddMessageConfigInterface
      * @see MessageConfig in ZddMessageFakerTest.php for a concret examples
      */
     public function generateValueForCustomPropertyType(string $type): mixed;
+
+    /**
+     * If you need full control over how a specific message instance is created,
+     * use this method to return a fully instantiated message object.
+     * This is useful when the default instantiation (using reflection and property injection)
+     * is not sufficient or when your message requires specific constructor logic.
+     *
+     * @template T of object
+     *
+     * @param class-string<T> $className
+     *
+     * @return ?T The fully instantiated message object, or null if the default instantiation should be used
+     */
+    public function generateCustomMessage(string $className): ?object;
 }

--- a/src/Config/ZddMessageConfigInterface.php
+++ b/src/Config/ZddMessageConfigInterface.php
@@ -51,18 +51,4 @@ interface ZddMessageConfigInterface
      * @see MessageConfig in ZddMessageFakerTest.php for a concret examples
      */
     public function generateValueForCustomPropertyType(string $type): mixed;
-
-    /**
-     * If you need full control over how a specific message instance is created,
-     * use this method to return a fully instantiated message object.
-     * This is useful when the default instantiation (using reflection and property injection)
-     * is not sufficient or when your message requires specific constructor logic.
-     *
-     * @template T of object
-     *
-     * @param class-string<T> $className
-     *
-     * @return ?T The fully instantiated message object, or null if the default instantiation should be used
-     */
-    public function generateCustomMessage(string $className): ?object;
 }

--- a/src/Factory/MessageGenerator.php
+++ b/src/Factory/MessageGenerator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yousign\ZddMessageBundle\Factory;
+
+use Yousign\ZddMessageBundle\Config\ZddMessageConfigInterface;
+use Yousign\ZddMessageBundle\Exceptions\MissingValueForTypeException;
+
+/**
+ * @internal
+ */
+final class MessageGenerator
+{
+    private readonly ZddPropertyExtractor $propertyExtractor;
+
+    public function __construct(private readonly ZddMessageConfigInterface $config)
+    {
+        $this->propertyExtractor = new ZddPropertyExtractor();
+    }
+
+    /**
+     * @param class-string $className
+     */
+    public function generate(string $className): object
+    {
+        $message = $this->config->generateCustomMessage($className);
+        if (null !== $message) {
+            return $message;
+        }
+
+        $message = (new \ReflectionClass($className))->newInstanceWithoutConstructor();
+        $propertyList = $this->propertyExtractor->extractPropertiesFromClass($className);
+
+        foreach ($propertyList->getProperties() as $property) {
+            $value = $property->isNullable ? null : $this->generateValueForProperty($property);
+            $this->forcePropertyValue($message, $property->name, $value);
+        }
+
+        return $message;
+    }
+
+    /**
+     * @throws MissingValueForTypeException
+     */
+    private function generateValueForProperty(Property $property): mixed
+    {
+        $value = $this->config->generateValueForCustomPropertyType($property->type);
+        if (null !== $value) {
+            return $value;
+        }
+
+        return match ($property->type) {
+            'string' => 'Hello World!',
+            'int' => 42,
+            'float' => 42.42,
+            'bool' => true,
+            'array' => ['PHP', 'For The Win'],
+            default => throw MissingValueForTypeException::missingValue($property->type, $this->config),
+        };
+    }
+
+    private function forcePropertyValue(object $object, string $property, mixed $value): void
+    {
+        $reflectionClass = new \ReflectionClass($object);
+        $reflectionProperty = $reflectionClass->getProperty($property);
+
+        // Readonly properties can only be set on the declaring class in case of inheritance
+        if ($reflectionProperty->isReadOnly()) {
+            $reflectionProperty = $reflectionProperty->getDeclaringClass()->getProperty($property);
+        }
+
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($object, $value);
+    }
+}

--- a/src/Factory/MessageGenerator.php
+++ b/src/Factory/MessageGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yousign\ZddMessageBundle\Factory;
 
+use Yousign\ZddMessageBundle\Config\CustomMessageGeneratorInterface;
 use Yousign\ZddMessageBundle\Config\ZddMessageConfigInterface;
 use Yousign\ZddMessageBundle\Exceptions\MissingValueForTypeException;
 
@@ -24,9 +25,11 @@ final class MessageGenerator
      */
     public function generate(string $className): object
     {
-        $message = $this->config->generateCustomMessage($className);
-        if (null !== $message) {
-            return $message;
+        if ($this->config instanceof CustomMessageGeneratorInterface) {
+            $message = $this->config->generateCustomMessage($className);
+            if (null !== $message) {
+                return $message;
+            }
         }
 
         $message = (new \ReflectionClass($className))->newInstanceWithoutConstructor();

--- a/src/Factory/Property.php
+++ b/src/Factory/Property.php
@@ -4,7 +4,7 @@ namespace Yousign\ZddMessageBundle\Factory;
 
 final class Property
 {
-    public function __construct(public readonly string $name, public readonly string $type, public readonly mixed $value)
+    public function __construct(public readonly string $name, public readonly string $type, public readonly bool $isNullable)
     {
     }
 }

--- a/src/Factory/PropertyList.php
+++ b/src/Factory/PropertyList.php
@@ -29,17 +29,21 @@ final class PropertyList
 
     public static function fromJson(string $data): self
     {
-        /** @var array<array<string,string>> $decodedProperties */
+        /** @var array<
+         *     array{name?: string, type?: string, isNullable?: bool}
+         * > $decodedProperties
+         */
         $decodedProperties = \json_decode($data, true);
         $properties = [];
         foreach ($decodedProperties as $decodedProperty) {
             $name = $decodedProperty['name'] ?? null;
             $type = $decodedProperty['type'] ?? null;
+            $isNullable = $decodedProperty['isNullable'] ?? null;
 
-            if (null === $name || null === $type) {
-                throw new \LogicException(sprintf('Missing keys name and/or type in decoded properties from data: "%s"', $data));
+            if (null === $name || null === $type || null === $isNullable) {
+                throw new \LogicException(sprintf('Missing keys name and/or type and/or isNullable in decoded properties from data: "%s"', $data));
             }
-            $properties[] = new Property($decodedProperty['name'], $decodedProperty['type'], null);
+            $properties[] = new Property($name, $type, $isNullable);
         }
 
         return new self($properties);
@@ -94,6 +98,7 @@ final class PropertyList
             $data[] = [
                 'name' => $property->name,
                 'type' => $property->type,
+                'isNullable' => $property->isNullable,
             ];
         }
 

--- a/src/Factory/ZddMessageFactory.php
+++ b/src/Factory/ZddMessageFactory.php
@@ -12,13 +12,13 @@ use Yousign\ZddMessageBundle\Serializer\SerializerInterface;
  */
 final class ZddMessageFactory
 {
-    private ZddMessageConfigInterface $config;
     private ZddPropertyExtractor $propertyExtractor;
+    private MessageGenerator $messageGenerator;
 
     public function __construct(ZddMessageConfigInterface $config, private readonly SerializerInterface $serializer)
     {
-        $this->config = $config;
-        $this->propertyExtractor = new ZddPropertyExtractor($config);
+        $this->propertyExtractor = new ZddPropertyExtractor();
+        $this->messageGenerator = new MessageGenerator($config);
     }
 
     /**
@@ -29,13 +29,7 @@ final class ZddMessageFactory
         try {
             $propertyList = $this->propertyExtractor->extractPropertiesFromClass($className);
 
-            $message = $this->config->generateCustomMessage($className);
-            if (null === $message) {
-                $message = (new \ReflectionClass($className))->newInstanceWithoutConstructor();
-                foreach ($propertyList->getProperties() as $property) {
-                    $this->forcePropertyValue($message, $property->name, $property->value);
-                }
-            }
+            $message = $this->messageGenerator->generate($className);
 
             $serializedMessage = $this->serializer->serialize($message);
         } catch (\Throwable $e) {
@@ -43,19 +37,5 @@ final class ZddMessageFactory
         }
 
         return new ZddMessage($className, $serializedMessage, $propertyList, $message);
-    }
-
-    private function forcePropertyValue(object $object, string $property, mixed $value): void
-    {
-        $reflectionClass = new \ReflectionClass($object);
-        $reflectionProperty = $reflectionClass->getProperty($property);
-
-        // Readonly properties can only be set on the declaring class in case of inheritance
-        if ($reflectionProperty->isReadOnly()) {
-            $reflectionProperty = $reflectionProperty->getDeclaringClass()->getProperty($property);
-        }
-
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($object, $value);
     }
 }

--- a/src/Factory/ZddPropertyExtractor.php
+++ b/src/Factory/ZddPropertyExtractor.php
@@ -2,24 +2,17 @@
 
 namespace Yousign\ZddMessageBundle\Factory;
 
-use Yousign\ZddMessageBundle\Config\ZddMessageConfigInterface;
 use Yousign\ZddMessageBundle\Exceptions\InvalidTypeException;
-use Yousign\ZddMessageBundle\Exceptions\MissingValueForTypeException;
 
 /**
  * @internal
  */
 final class ZddPropertyExtractor
 {
-    public function __construct(private readonly ZddMessageConfigInterface $config)
-    {
-    }
-
     /**
      * @param class-string $className
      *
      * @throws InvalidTypeException
-     * @throws MissingValueForTypeException
      * @throws \ReflectionException
      */
     public function extractPropertiesFromClass(string $className): PropertyList
@@ -40,31 +33,15 @@ final class ZddPropertyExtractor
                 throw InvalidTypeException::typeNotSupported();
             }
 
-            $typeHint = $propertyType->getName();
-            $value = $propertyType->allowsNull() ? null : $this->generateFakeValueFromType($typeHint);
-            $propertyList->addProperty(new Property($propertyName, $typeHint, $value));
+            $propertyList->addProperty(
+                new Property(
+                    $propertyName,
+                    $propertyType->getName(),
+                    $propertyType->allowsNull(),
+                ),
+            );
         }
 
         return $propertyList;
-    }
-
-    /**
-     * @throws MissingValueForTypeException
-     */
-    private function generateFakeValueFromType(string $typeHint): mixed
-    {
-        $value = $this->config->generateValueForCustomPropertyType($typeHint);
-        if (null !== $value) {
-            return $value;
-        }
-
-        return match ($typeHint) {
-            'string' => 'Hello World!',
-            'int' => 42,
-            'float' => 42.42,
-            'bool' => true,
-            'array' => ['PHP', 'For The Win'],
-            default => throw MissingValueForTypeException::missingValue($typeHint, $this->config),
-        };
     }
 }

--- a/src/ZddMessageBundle.php
+++ b/src/ZddMessageBundle.php
@@ -21,7 +21,6 @@ final class ZddMessageBundle extends AbstractBundle
 {
     public function configure(DefinitionConfigurator $definition): void
     {
-        /* @phpstan-ignore-next-line */
         $definition
             ->rootNode()
                 ->children()

--- a/tests/Fixtures/App/Messages/Config/MessageConfig.php
+++ b/tests/Fixtures/App/Messages/Config/MessageConfig.php
@@ -3,6 +3,7 @@
 namespace Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Config;
 
 use Yousign\ZddMessageBundle\Config\ZddMessageConfigInterface;
+use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyCustomMessage;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessage;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithAllManagedTypes;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithNullableNumberProperty;
@@ -15,6 +16,7 @@ class MessageConfig implements ZddMessageConfigInterface
 {
     public static array $messagesToAssert = [];
 
+    #[\Override]
     public function getMessageToAssert(): array
     {
         return [] !== self::$messagesToAssert ? self::$messagesToAssert : [
@@ -23,9 +25,11 @@ class MessageConfig implements ZddMessageConfigInterface
             DummyMessageWithPrivateConstructor::class,
             DummyMessageWithAllManagedTypes::class,
             Other\DummyMessage::class,
+            DummyCustomMessage::class,
         ];
     }
 
+    #[\Override]
     public function generateValueForCustomPropertyType(string $type): mixed
     {
         return match ($type) {
@@ -39,5 +43,15 @@ class MessageConfig implements ZddMessageConfigInterface
     public static function reset(): void
     {
         self::$messagesToAssert = [];
+    }
+
+    #[\Override]
+    public function generateCustomMessage(string $className): ?object
+    {
+        if (DummyCustomMessage::class === $className) {
+            return new DummyCustomMessage('custom message data');
+        }
+
+        return null;
     }
 }

--- a/tests/Fixtures/App/Messages/Config/MessageConfig.php
+++ b/tests/Fixtures/App/Messages/Config/MessageConfig.php
@@ -2,6 +2,7 @@
 
 namespace Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Config;
 
+use Yousign\ZddMessageBundle\Config\CustomMessageGeneratorInterface;
 use Yousign\ZddMessageBundle\Config\ZddMessageConfigInterface;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyCustomMessage;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessage;
@@ -12,7 +13,7 @@ use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Input\Locale;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Input\Status;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Other;
 
-class MessageConfig implements ZddMessageConfigInterface
+class MessageConfig implements ZddMessageConfigInterface, CustomMessageGeneratorInterface
 {
     public static array $messagesToAssert = [];
 

--- a/tests/Fixtures/App/Messages/DummyCustomMessage.php
+++ b/tests/Fixtures/App/Messages/DummyCustomMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages;
+
+final class DummyCustomMessage
+{
+    private string $content;
+
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+}

--- a/tests/Func/GenerateZddMessageCommandTest.php
+++ b/tests/Func/GenerateZddMessageCommandTest.php
@@ -50,6 +50,7 @@ class GenerateZddMessageCommandTest extends KernelTestCase
           3   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithPrivateConstructor      
           4   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithAllManagedTypes         
           5   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Other\DummyMessage                      
+          6   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyCustomMessage                      
          --- ---------------------------------------------------------------------------------------------  
         EOF;
 

--- a/tests/Func/ListZddMessageCommandTest.php
+++ b/tests/Func/ListZddMessageCommandTest.php
@@ -31,6 +31,7 @@ class ListZddMessageCommandTest extends KernelTestCase
           3   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithPrivateConstructor      
           4   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithAllManagedTypes         
           5   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Other\DummyMessage                      
+          6   Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyCustomMessage                      
          --- ---------------------------------------------------------------------------------------------  
         EOF;
 

--- a/tests/Func/ValidateZddMessageCommandTest.php
+++ b/tests/Func/ValidateZddMessageCommandTest.php
@@ -49,7 +49,7 @@ class ValidateZddMessageCommandTest extends KernelTestCase
     {
         mkdir($this->serializedMessagesDir);
         file_put_contents($this->serializedMessagesDir.'/DummyMessage.txt', $this->getSerializer()->serialize(new DummyMessage('Hi')));
-        file_put_contents($this->serializedMessagesDir.'/DummyMessage.properties.json', '[{"name":"content","type":"string"}]');
+        file_put_contents($this->serializedMessagesDir.'/DummyMessage.properties.json', '[{"name":"content","type":"string","isNullable":false}]');
         $this->assertSerializedFilesExist($this->serializedMessagesDir);
 
         $this->command->execute([]);
@@ -92,10 +92,12 @@ class ValidateZddMessageCommandTest extends KernelTestCase
             [
                 'name' => 'content',
                 'type' => 'string',
+                'isNullable' => false,
             ],
             [
                 'name' => 'number',
                 'type' => 'int',
+                'isNullable' => false,
             ],
         ];
         mkdir($this->serializedMessagesDir);
@@ -126,10 +128,12 @@ class ValidateZddMessageCommandTest extends KernelTestCase
             [
                 'name' => 'content',
                 'type' => 'string',
+                'isNullable' => false,
             ],
             [
                 'name' => 'number',
                 'type' => 'int',
+                'isNullable' => false,
             ],
         ];
         mkdir($this->serializedMessagesDir);

--- a/tests/Unit/ZddMessageAsserterTest.php
+++ b/tests/Unit/ZddMessageAsserterTest.php
@@ -42,7 +42,8 @@ class ZddMessageAsserterTest extends TestCase
             [
               {
                 "name": "content",
-                "type": "string"
+                "type": "string",
+                "isNullable": false
               }
             ]
             JSON,
@@ -55,11 +56,13 @@ class ZddMessageAsserterTest extends TestCase
             [
               {
                 "name": "content",
-                "type": "string"
+                "type": "string",
+                "isNullable": false
               },
               {
                 "name": "number",
-                "type": "int"
+                "type": "int",
+                "isNullable": false
               }
             ]
             JSON,
@@ -86,11 +89,13 @@ class ZddMessageAsserterTest extends TestCase
           [
             {
               "name": "content",
-              "type": "string"
+              "type": "string",
+              "isNullable": false
             },
             {
               "name": "number",
-              "type": "int"
+              "type": "int",
+              "isNullable": false
             }
           ]
         JSON;
@@ -124,7 +129,8 @@ class ZddMessageAsserterTest extends TestCase
         [
            {
               "name": "content",
-              "type": "int"
+              "type": "int",
+              "isNullable": false
             }
         ]
         JSON

--- a/tests/Unit/ZddMessageFactoryTest.php
+++ b/tests/Unit/ZddMessageFactoryTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Yousign\ZddMessageBundle\Exceptions\MissingValueForTypeException;
 use Yousign\ZddMessageBundle\Factory\ZddMessageFactory;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\Config\MessageConfig;
+use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyCustomMessage;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithAllManagedTypes;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithInheritedReadonlyProperty;
 use Yousign\ZddMessageBundle\Tests\Fixtures\App\Messages\DummyMessageWithNullableNumberProperty;
@@ -19,11 +20,16 @@ class ZddMessageFactoryTest extends TestCase
 {
     use SerializerTrait;
 
-    private readonly ZddMessageFactory $zddMessageFactory;
+    private ZddMessageFactory $zddMessageFactory;
 
     public function setUp(): void
     {
         $this->zddMessageFactory = new ZddMessageFactory(new MessageConfig(), $this->getSerializer());
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->zddMessageFactory);
     }
 
     public function testItGeneratesSerializedMessageWithNullAndNotNullableProperties(): void
@@ -112,6 +118,15 @@ class ZddMessageFactoryTest extends TestCase
         );
         $factory->create(WithoutValue::class);
     }
+
+    public function testGenerateCustomMessage(): void
+    {
+        $zddMessage = $this->zddMessageFactory->create(DummyCustomMessage::class);
+        self::assertEquals(1, $zddMessage->propertyList()->count());
+        self::assertSame('string', $zddMessage->propertyList()->get('content')->type);
+        // See the expected message in Fixtures\App\Messages\Config\MessageConfig::generateCustomMessage(...)
+        self::assertEquals(new DummyCustomMessage('custom message data'), $zddMessage->message());
+    }
 }
 
 namespace App\WithoutValue;
@@ -128,6 +143,7 @@ final class WithoutValue
 
 final class WithoutValueConfig implements ZddMessageConfigInterface
 {
+    #[\Override]
     public function getMessageToAssert(): array
     {
         return [
@@ -135,7 +151,14 @@ final class WithoutValueConfig implements ZddMessageConfigInterface
         ];
     }
 
+    #[\Override]
     public function generateValueForCustomPropertyType(string $type): mixed
+    {
+        return null;
+    }
+
+    #[\Override]
+    public function generateCustomMessage(string $className): ?object
     {
         return null;
     }

--- a/tests/Unit/ZddMessageFactoryTest.php
+++ b/tests/Unit/ZddMessageFactoryTest.php
@@ -152,10 +152,4 @@ final class WithoutValueConfig implements ZddMessageConfigInterface
     {
         return null;
     }
-
-    #[\Override]
-    public function generateCustomMessage(string $className): ?object
-    {
-        return null;
-    }
 }

--- a/tests/Unit/ZddMessageFactoryTest.php
+++ b/tests/Unit/ZddMessageFactoryTest.php
@@ -44,11 +44,9 @@ class ZddMessageFactoryTest extends TestCase
         self::assertTrue($zddMessage->propertyList()->has('content'));
         $property = $zddMessage->propertyList()->get('content');
         self::assertSame('string', $property->type);
-        self::assertSame('Hello World!', $property->value);
 
         $propertyNumber = $zddMessage->propertyList()->get('number');
         self::assertSame('int', $propertyNumber->type);
-        self::assertNull($propertyNumber->value);
     }
 
     public function testItGeneratesSerializedMessageForDummyMessageWithInheritedReadonlyProperty(): void
@@ -64,7 +62,6 @@ class ZddMessageFactoryTest extends TestCase
         self::assertTrue($zddMessage->propertyList()->has('content'));
         $property = $zddMessage->propertyList()->get('content');
         self::assertSame('string', $property->type);
-        self::assertSame('Hello World!', $property->value);
     }
 
     public function testItGeneratesSerializedMessageForDummyMessageWithPrivateConstructor(): void
@@ -79,7 +76,6 @@ class ZddMessageFactoryTest extends TestCase
         self::assertTrue($zddMessage->propertyList()->has('content'));
         $property = $zddMessage->propertyList()->get('content');
         self::assertSame('string', $property->type);
-        self::assertSame('Hello World!', $property->value);
     }
 
     public function testItGeneratesSerializedMessageForDummyMessageContainingAllManagedTypesWithoutError(): void


### PR DESCRIPTION
                                                                                                             
  This PR introduces optional custom message generation through a new `CustomMessageGeneratorInterface`,      
  allowing users to have full control over how specific message instances are created.                        
                                                                                                              
  ### Changes                                                                                                  
                                                                                                              
  - Added `CustomMessageGeneratorInterface` with `generateCustomMessage()` method                             
  - Extracted `MessageGenerator` class to centralize message creation logic                                   
  - Updated `ZddMessageFactory` to delegate message generation to `MessageGenerator`                          
  - Added documentation and example usage in README                                                           
                                                                                                              
  ### Notes                                                                                                    
                                                                                                              
  - `CustomMessageGeneratorInterface` is optional and separate from `ZddMessageConfigInterface`               
  - Users can implement both interfaces in the same class if they need custom instantiation                   
  - Custom message instantiation is useful when the default reflection-based approach is insufficient or when 
  messages require specific constructor logic 