### PR TITLE
feat: support Symfony 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,17 +28,26 @@ jobs:
     name: PHPStan
     steps:
       - uses: actions/checkout@v3
-      - uses: php-actions/composer@v6 # or alternative dependency management
-      - uses: php-actions/phpstan@v3
+
+      # Runs the PHPStan the project depends on, with the command from the Makefile. The
+      # php-actions/phpstan action brings its own version, which cannot be kept in step with
+      # composer.json — and PHPStan 1 cannot parse Symfony 8.
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          path: src/
-          level: 9
+          php-version: '8.4'
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress
+
+      - name: PHPStan
+        run: vendor/bin/phpstan analyse src --level=9
 
   phpunit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
         mode: ['high-deps', 'low-deps']
       fail-fast: false
     name: PHP ${{ matrix.php-versions }} tests with ${{ matrix.mode }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           tools: php-cs-fixer
 
       - name: PHP Coding Standards Fixer
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.4', '8.5']
         mode: ['high-deps', 'low-deps']
       fail-fast: false
     name: PHP ${{ matrix.php-versions }} tests with ${{ matrix.mode }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A Symfony Bundle to use when you want to assert that messages used with Message brokers such like RabbitMQ are compliant with the Zero Downtime Deployment.
 
+## Requirements
+
+- PHP 8.1 and above
+- Symfony 6.2, 7 or 8
+
 ## Getting started
 ### Installation
 First, install the bundle with composer:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A Symfony Bundle to use when you want to assert that messages used with Message 
 
 ## Requirements
 
-- PHP 8.1 and above
-- Symfony 6.2, 7 or 8
+- PHP 8.4 and above
+- Symfony 7.4 or 8
 
 ## Getting started
 ### Installation

--- a/composer.json
+++ b/composer.json
@@ -8,16 +8,16 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1.0",
-        "symfony/console": "^6.2|^7.0"
+        "symfony/console": "^6.2|^7.0|^8.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^9.5",
         "friendsofphp/php-cs-fixer": "^3.1",
-        "symfony/browser-kit": "^6.2|^7.0",
-        "symfony/framework-bundle": "^6.2|^7.0",
-        "symfony/yaml": "^6.2|^7.0",
-        "symfony/messenger": "^6.2|^7.0"
+        "symfony/browser-kit": "^6.2|^7.0|^8.0",
+        "symfony/framework-bundle": "^6.2|^7.0|^8.0",
+        "symfony/yaml": "^6.2|^7.0|^8.0",
+        "symfony/messenger": "^6.2|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,17 +7,17 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": "^8.1.0",
-        "symfony/console": "^6.2|^7.0|^8.0"
+        "php": "^8.4",
+        "symfony/console": "^7.4|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^9.5",
         "friendsofphp/php-cs-fixer": "^3.1",
-        "symfony/browser-kit": "^6.2|^7.0|^8.0",
-        "symfony/framework-bundle": "^6.2|^7.0|^8.0",
-        "symfony/yaml": "^6.2|^7.0|^8.0",
-        "symfony/messenger": "^6.2|^7.0|^8.0"
+        "symfony/browser-kit": "^7.4|^8.0",
+        "symfony/framework-bundle": "^7.4|^8.0",
+        "symfony/yaml": "^7.4|^8.0",
+        "symfony/messenger": "^7.4|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Factory/MessageGenerator.php
+++ b/src/Factory/MessageGenerator.php
@@ -73,7 +73,7 @@ final class MessageGenerator
             $reflectionProperty = $reflectionProperty->getDeclaringClass()->getProperty($property);
         }
 
-        $reflectionProperty->setAccessible(true);
+        // No setAccessible() call: it has had no effect since PHP 8.1 and is deprecated in 8.5.
         $reflectionProperty->setValue($object, $value);
     }
 }

--- a/src/Serializer/ZddMessageMessengerSerializer.php
+++ b/src/Serializer/ZddMessageMessengerSerializer.php
@@ -21,19 +21,25 @@ class ZddMessageMessengerSerializer implements SerializerInterface
 
     public function deserialize(string $data): object
     {
-        /** @var array{body: string, headers?: array<string, string>} $dataArray */
-        $dataArray = \json_decode($data, true, 512, \JSON_THROW_ON_ERROR);
-        if (!\is_array($dataArray)) {
-            throw new \InvalidArgumentException(sprintf('Array expected, %s provided', \gettype($data)));
+        $decoded = \json_decode($data, true, 512, \JSON_THROW_ON_ERROR);
+        if (!\is_array($decoded)) {
+            throw new \InvalidArgumentException(sprintf('Array expected, %s provided', \gettype($decoded)));
         }
 
+        /** @var array{body: string, headers?: array<string, string>} $encodedEnvelope */
+        $encodedEnvelope = $decoded;
+
         try {
-            $envelope = $this->serializer->decode($dataArray);
-            if (!$envelope instanceof Envelope) {
-                throw new \InvalidArgumentException(sprintf('%s expected, %s provided', Envelope::class, \gettype($data)));
+            $message = $this->serializer->decode($encodedEnvelope)->getMessage();
+
+            // Since Symfony 8, PhpSerializer no longer throws when a message cannot be rebuilt:
+            // MessageDecodingFailedException::wrap() returns an envelope carrying the failure as
+            // its message. Earlier versions throw, which the catch below still handles.
+            if ($message instanceof MessageDecodingFailedException) {
+                throw new UnableToDeserializeException(previous: $message);
             }
 
-            return $envelope->getMessage();
+            return $message;
         } catch (MessageDecodingFailedException $e) {
             throw new UnableToDeserializeException(previous: $e);
         }


### PR DESCRIPTION
Adds Symfony 8 support, so the bundle can be installed on an application running Symfony 8.1 and PHP 8.5.

Same need as [safe-migrations#7](https://github.com/Yousign/safe-migrations/pull/7): a new Yousign service runs ahead of the rest of the estate, and `symfony/console: ^6.2|^7.0` blocked the install.

## One real behaviour change, not just constraints

Widening the constraints was not enough. **Symfony 8 changed how a message that cannot be rebuilt is reported.**

`MessageDecodingFailedException::wrap()` no longer throws. It returns an `Envelope` whose *message* is the exception:

```php
// vendor/symfony/messenger/Exception/MessageDecodingFailedException.php
public static function wrap(array $encodedEnvelope, string $message, ...): Envelope
{
    return new Envelope(new self($message, $code, $previous, $encodedEnvelope));
}
```

`ZddMessageMessengerSerializer::deserialize()` catches `MessageDecodingFailedException`, which now never arrives. It returned the exception object as if it were the message, and `ZddMessageAsserter` then reported:

> Class mismatch between `$messageFqcn` … Please verify your integration.

That is the wrong answer to the right question: a message that no longer deserializes is exactly the zero-downtime breach this bundle exists to catch, and the user was told to check their integration instead. `deserialize()` now recognises both shapes — the returned envelope on Symfony 8, and the thrown exception on 6.2 and 7.

`ZddMessageAsserterTest::testItThrowsExceptionForInvalidPropertyType` is what surfaced it.

## The rest

- **PHPStan `^1.10` → `^2.1`.** PHPStan 1.x cannot parse Symfony 8 and reports its classes as unknown (`extends unknown class Symfony\Component\Console\Command\Command`). Under PHPStan 2 the `@var` on the `json_decode()` result no longer holds, so it moves to the assignment it actually describes, and the redundant `instanceof Envelope` check goes — `decode()` is typed `: Envelope`.
- **`ReflectionProperty::setAccessible()` removed** from `MessageGenerator`. Deprecated in PHP 8.5, and without effect since 8.1. Left in place it makes every PHP 8.5 run noisy.
- **CI matrix gains PHP 8.4 and 8.5**, in both `high-deps` and `low-deps`. Without them the new support is never exercised.
- **The PHPStan job now runs the project's own PHPStan**, with the command from the Makefile. `php-actions/phpstan` brings its own version, which cannot be kept in step with `composer.json`. This is the one change I could not run locally, so it is the job to watch on this PR.
- `composer.lock` is gitignored here, so it is not part of the diff.

## How this was checked

Every command below ran on **PHP 8.5.9**, in the Docker image of the application that needs this bundle.

| Check | Result |
|---|---|
| `vendor/bin/phpunit`, Symfony 8.1 | 26 tests, 78 assertions, green |
| `vendor/bin/phpunit`, `--prefer-lowest` (Symfony 6.2) | 25 tests, 77 assertions, green |
| `vendor/bin/phpstan analyse src --level=9` | no errors |
| `vendor/bin/php-cs-fixer --dry-run fix src` | no change |

The low-deps run first failed with 6 errors. That was a stale `var/cache` left by the previous run, not an incompatibility — it passes from a clean cache. Worth knowing if you see the same locally.
